### PR TITLE
May: Upgrade to torch 2.8, Composer 0.32, and add GPU device checks

### DIFF
--- a/SGC_geneformer/train.py
+++ b/SGC_geneformer/train.py
@@ -290,6 +290,26 @@ def main(cfg: DictConfig):
     reproducibility.configure_deterministic_mode()
     reproducibility.seed_all(seed_val)
 
+    if torch.cuda.is_available():
+        gpu_count = torch.cuda.device_count()
+        print(f"[gpu-check] CUDA_VISIBLE_DEVICES={os.getenv('CUDA_VISIBLE_DEVICES')}")
+        print(f"[gpu-check] torch.cuda.device_count()={gpu_count}")
+        for i in range(gpu_count):
+            p = torch.cuda.get_device_properties(i)
+            print(f"[gpu-check] {i}: {p.name} {p.total_memory/1e9:.1f} GB")
+    else:
+        print("[gpu-check] CUDA not available")
+    print(
+        f"[gpu-check] NNODES={os.getenv('NNODES')} "
+        f"NPROC_PER_NODE={os.getenv('NPROC_PER_NODE')} "
+        f"WORLD_SIZE={os.getenv('WORLD_SIZE')}"
+    )
+    print(
+        f"[gpu-check] MASTER_ADDR={os.getenv('MASTER_ADDR')} "
+        f"MASTER_PORT={os.getenv('MASTER_PORT')} "
+        f"NODE_RANK={os.getenv('NODE_RANK')}"
+    )
+
     loggers = [
         build_logger(name, logger_cfg)
         for name, logger_cfg in cfg.get('loggers', {}).items()


### PR DESCRIPTION
Integrate the below changes and testings @hengrumay has done:

## Summary
- **Upgrade dependencies**: torch 2.8.0, torchvision 0.23.0, mosaicml 0.32.1, mosaicml-streaming 0.13.0, mlflow >=3.6.0
- **Fix Composer 0.32 breaking change**: Replace deprecated `fsdp_config` with `parallelism_config` in Trainer
- **Add GPU/device check**: Log GPU count, device names, memory, and distributed env vars (NNODES, WORLD_SIZE, MASTER_ADDR, etc.) on each rank for multi-node debugging
- **Update SGCLI wheel**: 0.0.3 → 0.0.4
- **Update README**: Reflect new wheel version and dependency versions

## Changes
- `SGC_geneformer/train.py` — `parallelism_config` fix + GPU check block
- `SGC_geneformer/commands.sh` — Install torch 2.8.0 with CUDA 12.6
- `SGC_geneformer/dependencies.yaml` — Updated package versions
- `SGC_geneformer/requirements.txt` — Updated package versions
- `SGC_geneformer/parameters.yaml` — Minor config update
- `README.md` — Updated wheel and dependency versions
- `sgcli_wheel/` — Added 0.0.4 wheel

## Test plan
- [x] Submit hello world job with `sgcli run -f train_workload.yaml --watch` to verify setup
- [x] Submit geneformer training with `sgcli run -f train.yaml --watch`
- [x] Verify `[gpu-check]` logs appear for all ranks showing correct GPU count and device info
- [x] Confirm training completes without `fsdp_config` / `parallelism_config` errors